### PR TITLE
Fixes #3

### DIFF
--- a/simpleSchedule/converting_timestamps.py
+++ b/simpleSchedule/converting_timestamps.py
@@ -19,7 +19,8 @@ def time_stamp_return(day):
             with open('schedule.txt', 'r') as f:
                 tempApps = f.read()
                 converted = json.loads(tempApps)
-                return convert_time(parse_timestamps(converted[day].keys()))
+                parse_timestamps(converted[day].keys())
+                return parse_timestamps(converted[day].keys()), convert_time(parse_timestamps(converted[day].keys()))
 
 def main():
     day = input("Which day do you want to know about? : ")

--- a/simpleSchedule/converting_timestamps.py
+++ b/simpleSchedule/converting_timestamps.py
@@ -5,14 +5,6 @@ def parse_timestamps(time_stamp_test):
     time_stamps = [i for i in time_stamp_test]
     return time_stamps
 
-
-def convert_time(time_stamps):
-    time_stamps_new = []
-    for timestamp in time_stamps:
-        time = ':'.join([timestamp[0:2], timestamp[2:4]])
-        time_stamps_new.append(time)
-    return time_stamps_new
-
 def time_stamp_return(day):
     schedule = []
     if os.path.isfile('schedule.txt'):
@@ -20,7 +12,7 @@ def time_stamp_return(day):
                 tempApps = f.read()
                 converted = json.loads(tempApps)
                 parse_timestamps(converted[day].keys())
-                return parse_timestamps(converted[day].keys()), convert_time(parse_timestamps(converted[day].keys()))
+                return parse_timestamps(converted[day].keys())
 
 def main():
     day = input("Which day do you want to know about? : ")

--- a/simpleSchedule/schedule.txt
+++ b/simpleSchedule/schedule.txt
@@ -1,15 +1,15 @@
 {
     "sunday": {
-        "2255": {
-            "STS1007": [
-                "https://www.google.com",
-                "https://www.youtube.com"
+        "23:30": {
+            "MGT1002": [
+                "https://www.youtube.com",
+                "https://www.google.com"
             ]
         },
-        "2259": {
-            "CHY1004": [
-                "https://www.youtube.com",
-                "https://www.github.com"
+        "23:31": {
+            "HUM1032": [
+                "https://www.github.com",
+                "https://www.github.com/Naruita"
             ]
         }
     }

--- a/simpleSchedule/schedule.txt
+++ b/simpleSchedule/schedule.txt
@@ -1,12 +1,12 @@
 {
     "sunday": {
-        "1942": {
+        "2255": {
             "STS1007": [
                 "https://www.google.com",
                 "https://www.youtube.com"
             ]
         },
-        "1943": {
+        "2259": {
             "CHY1004": [
                 "https://www.youtube.com",
                 "https://www.github.com"

--- a/simpleSchedule/schedule_module_check.py
+++ b/simpleSchedule/schedule_module_check.py
@@ -9,15 +9,14 @@ def find_day():
     day = week_days[datetime.date.today().weekday()]
     return day
 
-def scheduling(links):
-    
+def scheduling(timestamp, links):
     day = find_day()
-    for timestamp in temp_stamps:
-        schedule.every().day.at(timestamp).do(deploy.deploy_links, links)
+    schedule.every().day.at(timestamp).do(deploy.deploy_links, links)
 
     while True:
         schedule.run_pending()
         time.sleep(1)
+        
 
 if __name__ == "__main__":
     temp_stamps = ct.time_stamp_return(find_day())

--- a/simpleSchedule/schedule_module_check.py
+++ b/simpleSchedule/schedule_module_check.py
@@ -9,8 +9,8 @@ def find_day():
     day = week_days[datetime.date.today().weekday()]
     return day
 
-def main(links):
-    temp_stamps = ct.time_stamp_return(find_day())
+def scheduling(links):
+    
     day = find_day()
     for timestamp in temp_stamps:
         schedule.every().day.at(timestamp).do(deploy.deploy_links, links)
@@ -20,4 +20,5 @@ def main(links):
         time.sleep(1)
 
 if __name__ == "__main__":
-    main(["https://www.google.com", "https://www.youtube.com"])
+    temp_stamps = ct.time_stamp_return(find_day())
+    scheduling(temp_stamps, ["https://www.google.com", "https://www.youtube.com"])

--- a/simpleSchedule/timed_link.py
+++ b/simpleSchedule/timed_link.py
@@ -31,10 +31,10 @@ def main():
             days = converted.keys()
             schedule.append(converted.values())
 
-    unformatted_timestamps, timestamps = ct.time_stamp_return(find_day()) # unformatted_timestamps -> 1900, timestamps -> 19:00
-    for timestamp in unformatted_timestamps:
+    timestamps = ct.time_stamp_return(find_day()) # unformatted_timestamps -> 1900, timestamps -> 19:00
+    for timestamp in timestamps:
         print(timestamp)
         temp_links = parse_file_link(converted[find_day()][timestamp])
-        smc.scheduling(temp_links)
+        smc.scheduling(timestamp, temp_links)
 
 main()

--- a/simpleSchedule/timed_link.py
+++ b/simpleSchedule/timed_link.py
@@ -4,7 +4,9 @@ from time import sleep
 import time
 import os
 import json
+import converting_timestamps as ct
 import deploy
+import schedule_module_check as smc
 
 # function to provide the current day the user is in.
 def find_day():
@@ -29,9 +31,10 @@ def main():
             days = converted.keys()
             schedule.append(converted.values())
 
-    timestamp = '0900' # just need to get the timestamps now.
-
-    temp_links = parse_file_link(converted[find_day()][timestamp])
-    deploy.deploy_links(temp_links)
+    unformatted_timestamps, timestamps = ct.time_stamp_return(find_day()) # unformatted_timestamps -> 1900, timestamps -> 19:00
+    for timestamp in unformatted_timestamps:
+        print(timestamp)
+        temp_links = parse_file_link(converted[find_day()][timestamp])
+        smc.scheduling(temp_links)
 
 main()

--- a/simpleSchedule/timetablemaker.py
+++ b/simpleSchedule/timetablemaker.py
@@ -6,7 +6,7 @@ class day_timetable:
         self.time_table = {}
 
     def get_info(self):
-        self.in_time = input("Enter time in HHMM format : ")
+        self.in_time = input("Enter time in HH:MM format : ")
         self.course_code = input("Enter the course code : ").upper()
         self.links = []
         print("Add links now. Type 'quit' to stop.")


### PR DESCRIPTION
Fixed
---
- Got rid of an entire section of converting_timestamps, which can simply be avoided by the user giving the correct format.
- All of the sections of the program for the deployment are now integrated adequately.
- #3 Deploys at the right time now.
- Deploys multiple URLs at the correct time.

New issues spotted and to be added
---
- Only works for one day.
- Time stamps seem to be swapping out in the program **timed_link.py, line 35**
- schedule.run_pending() does not quit after the execution of the deployment